### PR TITLE
Fix coroutine activity check in DefaultCoreTimer

### DIFF
--- a/core/timer-core/src/main/java/me/rezapour/timer_core/impl/DefaultTimerEngine.kt
+++ b/core/timer-core/src/main/java/me/rezapour/timer_core/impl/DefaultTimerEngine.kt
@@ -2,7 +2,8 @@ package me.rezapour.timer_core.impl
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.NonCancellable.isActive
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -117,7 +118,7 @@ class DefaultCoreTimer(
     private fun startJob() {
         stopJob()
         job = scope.launch {
-            while (isActive && _status.value == CoreTimerStatus.Running) {
+            while (currentCoroutineContext().isActive && _status.value == CoreTimerStatus.Running) {
                 delay(tickMs)
                 tickOnce()
             }


### PR DESCRIPTION
### Motivation
- Ensure the timer loop respects coroutine cancellation by checking the actual coroutine context `isActive` instead of the previously imported `NonCancellable.isActive`.

### Description
- In `core/timer-core/src/main/java/me/rezapour/timer_core/impl/DefaultTimerEngine.kt` replaced `import kotlinx.coroutines.NonCancellable.isActive` with `import kotlinx.coroutines.currentCoroutineContext` and `import kotlinx.coroutines.isActive`, and updated the loop to `while (currentCoroutineContext().isActive && _status.value == CoreTimerStatus.Running)` so cancellation is evaluated against the running job.

### Testing
- Ran `./gradlew test` and `./gradlew :core:timer-core:test --stacktrace`, both could not complete in this environment due to a Gradle/Kotlin JVM version parse error (`IllegalArgumentException: 25.0.1`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d17bfe30c88322b6e8e1c7460a8918)